### PR TITLE
Reports status of the integration commit after the build has finished

### DIFF
--- a/src/main/java/com/mhackner/bamboo/AbstractGitHubStatusAction.java
+++ b/src/main/java/com/mhackner/bamboo/AbstractGitHubStatusAction.java
@@ -67,6 +67,12 @@ public abstract class AbstractGitHubStatusAction {
         }
     }
 
+    void updateStatus(ChainExecution chainExecution) {
+        for (StageExecution stageExecution : chainExecution.getStages()) {
+            updateStatus(stageExecution);
+        }
+    }
+
     void updateStatusForMerge(ChainResultsSummary resultsSummary, ChainExecution chainExecution) {
         MergeResultSummary mergeResultSummary = resultsSummary.getMergeResult();
         if (mergeResultSummary == null) {
@@ -102,7 +108,7 @@ public abstract class AbstractGitHubStatusAction {
     }
 
     private static GHCommitState statusOf(StageExecution stageExecution) {
-        if (stageExecution.isCompleted()) {
+        if (stageExecution.isCompleted() || stageExecution.getChainExecution().isCompleted()) {
             if (stageExecution.isSuccessful()) {
                 return GHCommitState.SUCCESS;
             } else if (Iterables.any(stageExecution.getBuilds(), new Predicate<BuildExecution>() {

--- a/src/main/java/com/mhackner/bamboo/AbstractGitHubStatusAction.java
+++ b/src/main/java/com/mhackner/bamboo/AbstractGitHubStatusAction.java
@@ -1,8 +1,14 @@
 package com.mhackner.bamboo;
 
+import com.atlassian.bamboo.builder.BuildState;
+import com.atlassian.bamboo.chains.BuildExecution;
 import com.atlassian.bamboo.chains.ChainExecution;
+import com.atlassian.bamboo.chains.ChainResultsSummary;
 import com.atlassian.bamboo.chains.StageExecution;
+import com.atlassian.bamboo.chains.branches.MergeResultState;
+import com.atlassian.bamboo.chains.branches.MergeResultSummary;
 import com.atlassian.bamboo.configuration.AdministrationConfigurationAccessor;
+import com.atlassian.bamboo.plan.PlanHelper;
 import com.atlassian.bamboo.plan.PlanKey;
 import com.atlassian.bamboo.plan.PlanManager;
 import com.atlassian.bamboo.plan.PlanResultKey;
@@ -43,7 +49,8 @@ public abstract class AbstractGitHubStatusAction {
         this.planManager = planManager;
     }
 
-    void updateStatus(GHCommitState status, StageExecution stageExecution) {
+    void updateStatus(StageExecution stageExecution) {
+        GHCommitState status = statusOf(stageExecution);
         ChainExecution chainExecution = stageExecution.getChainExecution();
         PlanResultKey planResultKey = chainExecution.getPlanResultKey();
         PlanKey planKey = planResultKey.getPlanKey();
@@ -57,6 +64,59 @@ public abstract class AbstractGitHubStatusAction {
                     setStatus(ghRepo, status, sha, planResultKey.getKey(), stageExecution.getName());
                 }
             }
+        }
+    }
+
+    void updateStatusForMerge(ChainResultsSummary resultsSummary, ChainExecution chainExecution) {
+        MergeResultSummary mergeResultSummary = resultsSummary.getMergeResult();
+        if (mergeResultSummary == null) {
+            log.debug("No merge summary present; skipping status update for merge");
+            return;
+        } else if (mergeResultSummary.getMergeState() != MergeResultState.SUCCESS) {
+            log.info("Merge state was {}; skipping status update for merge", mergeResultSummary.getMergeState());
+            return;
+        }
+
+        PlanResultKey planResultKey = chainExecution.getPlanResultKey();
+        PlanKey planKey = planResultKey.getPlanKey();
+        ImmutableChain chain = (ImmutableChain) planManager.getPlanByKey(planKey);
+        if (chain == null) {
+            return;
+        }
+
+        RepositoryDefinition defaultRepo = PlanHelper.getDefaultRepositoryDefinition(chain);
+        if (defaultRepo == null || !shouldUpdateRepo(chain, defaultRepo)) {
+            return;
+        }
+        GitHubRepository ghRepo = (GitHubRepository) defaultRepo.getRepository();
+
+        String sha = mergeResultSummary.getMergeResultVcsKey();
+        if (sha == null) {
+            return;
+        }
+
+        for (StageExecution stageExecution : chainExecution.getStages()) {
+            GHCommitState status = statusOf(stageExecution);
+            setStatus(ghRepo, status, sha, planResultKey.getKey(), stageExecution.getName());
+        }
+    }
+
+    private static GHCommitState statusOf(StageExecution stageExecution) {
+        if (stageExecution.isCompleted()) {
+            if (stageExecution.isSuccessful()) {
+                return GHCommitState.SUCCESS;
+            } else if (Iterables.any(stageExecution.getBuilds(), new Predicate<BuildExecution>() {
+                @Override
+                public boolean apply(BuildExecution input) {
+                    return input.getBuildState() == BuildState.UNKNOWN;
+                }
+            })) {
+                return GHCommitState.ERROR;
+            } else {
+                return GHCommitState.FAILURE;
+            }
+        } else {
+            return GHCommitState.PENDING;
         }
     }
 

--- a/src/main/java/com/mhackner/bamboo/GitHubStatusPostChain.java
+++ b/src/main/java/com/mhackner/bamboo/GitHubStatusPostChain.java
@@ -18,6 +18,7 @@ public class GitHubStatusPostChain extends AbstractGitHubStatusAction implements
     public void execute(@NotNull Chain chain,
                         @NotNull ChainResultsSummary chainResultsSummary,
                         @NotNull ChainExecution chainExecution) {
+        updateStatus(chainExecution);
         updateStatusForMerge(chainResultsSummary, chainExecution);
     }
 }

--- a/src/main/java/com/mhackner/bamboo/GitHubStatusPostChain.java
+++ b/src/main/java/com/mhackner/bamboo/GitHubStatusPostChain.java
@@ -1,0 +1,23 @@
+package com.mhackner.bamboo;
+
+import com.atlassian.bamboo.chains.Chain;
+import com.atlassian.bamboo.chains.ChainExecution;
+import com.atlassian.bamboo.chains.ChainResultsSummary;
+import com.atlassian.bamboo.chains.plugins.PostChainAction;
+import com.atlassian.bamboo.configuration.AdministrationConfigurationAccessor;
+import com.atlassian.bamboo.plan.PlanManager;
+import com.atlassian.bamboo.security.EncryptionService;
+import org.jetbrains.annotations.NotNull;
+
+public class GitHubStatusPostChain extends AbstractGitHubStatusAction implements PostChainAction {
+    public GitHubStatusPostChain(AdministrationConfigurationAccessor adminConfigAccessor, EncryptionService encryptionService, PlanManager planManager) {
+        super(adminConfigAccessor, encryptionService, planManager);
+    }
+
+    @Override
+    public void execute(@NotNull Chain chain,
+                        @NotNull ChainResultsSummary chainResultsSummary,
+                        @NotNull ChainExecution chainExecution) {
+        updateStatusForMerge(chainResultsSummary, chainExecution);
+    }
+}

--- a/src/main/java/com/mhackner/bamboo/GitHubStatusPostStage.java
+++ b/src/main/java/com/mhackner/bamboo/GitHubStatusPostStage.java
@@ -1,7 +1,5 @@
 package com.mhackner.bamboo;
 
-import com.atlassian.bamboo.builder.BuildState;
-import com.atlassian.bamboo.chains.BuildExecution;
 import com.atlassian.bamboo.chains.ChainResultsSummary;
 import com.atlassian.bamboo.chains.ChainStageResult;
 import com.atlassian.bamboo.chains.StageExecution;
@@ -9,11 +7,8 @@ import com.atlassian.bamboo.chains.plugins.PostStageAction;
 import com.atlassian.bamboo.configuration.AdministrationConfigurationAccessor;
 import com.atlassian.bamboo.plan.PlanManager;
 import com.atlassian.bamboo.security.EncryptionService;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
 
 import org.jetbrains.annotations.NotNull;
-import org.kohsuke.github.GHCommitState;
 
 public class GitHubStatusPostStage extends AbstractGitHubStatusAction implements PostStageAction {
 
@@ -27,22 +22,7 @@ public class GitHubStatusPostStage extends AbstractGitHubStatusAction implements
     public void execute(@NotNull ChainResultsSummary chainResultsSummary,
                         @NotNull ChainStageResult chainStageResult,
                         @NotNull StageExecution stageExecution) {
-        updateStatus(statusOf(stageExecution), stageExecution);
-    }
-
-    private static GHCommitState statusOf(StageExecution stageExecution) {
-        if (stageExecution.isSuccessful()) {
-            return GHCommitState.SUCCESS;
-        } else if (Iterables.any(stageExecution.getBuilds(), new Predicate<BuildExecution>() {
-            @Override
-            public boolean apply(BuildExecution input) {
-                return input.getBuildState() == BuildState.UNKNOWN;
-            }
-        })) {
-            return GHCommitState.ERROR;
-        } else {
-            return GHCommitState.FAILURE;
-        }
+        updateStatus(stageExecution);
     }
 
 }

--- a/src/main/java/com/mhackner/bamboo/GitHubStatusPreStage.java
+++ b/src/main/java/com/mhackner/bamboo/GitHubStatusPreStage.java
@@ -7,7 +7,6 @@ import com.atlassian.bamboo.plan.PlanManager;
 import com.atlassian.bamboo.security.EncryptionService;
 
 import org.jetbrains.annotations.NotNull;
-import org.kohsuke.github.GHCommitState;
 
 public class GitHubStatusPreStage extends AbstractGitHubStatusAction implements PreStageAction {
 
@@ -19,7 +18,7 @@ public class GitHubStatusPreStage extends AbstractGitHubStatusAction implements 
 
     @Override
     public void execute(@NotNull StageExecution stageExecution) {
-        updateStatus(GHCommitState.PENDING, stageExecution);
+        updateStatus(stageExecution);
     }
 
 }

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -9,6 +9,7 @@
 
     <preStageAction key="gitHubStatusPreStage" class="com.mhackner.bamboo.GitHubStatusPreStage" />
     <postStageAction key="gitHubStatusPostStage" class="com.mhackner.bamboo.GitHubStatusPostStage" />
+    <postChainAction key="gitHubStatusPostChain" class="com.mhackner.bamboo.GitHubStatusPostChain" />
 
     <additionalBuildConfigurationPlugin key="configuration" class="com.mhackner.bamboo.Configuration">
         <resource type="freemarker" name="edit" location="com/mhackner/bamboo-github-status/edit.ftl" />


### PR DESCRIPTION
When using the [branch updater](https://confluence.atlassian.com/bamboo/using-plan-branches-289276872.html#Usingplanbranches-Branchupdater) feature of Bamboo, while the tests are run against an integrated branch, the commit is not pushed until the build is completed. This PR proposes pushing status to the merge commit resulting from a branch updater after the entire chain is finished.
