### PR TITLE
Use newer Bamboo and github-api, fixes #21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,8 @@
     </scm>
 
     <properties>
-        <bamboo.version>5.9.1</bamboo.version>
-        <bamboo.data.version>5.9.1</bamboo.data.version>
+        <bamboo.version>5.15.0.1</bamboo.version>
+        <bamboo.data.version>5.15.0.1</bamboo.data.version>
         <amps.version>6.1.2</amps.version>
         <plugin.testrunner.version>1.2.3</plugin.testrunner.version>
     </properties>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.kohsuke</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.69</version>
+            <version>1.84</version>
         </dependency>
         <dependency>
             <groupId>com.atlassian.bamboo</groupId>
@@ -106,7 +106,32 @@
             </plugin>
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.3</version>
+                <executions>
+                    <execution>
+                        <id>unpack-dependencies</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <excludes>META-INF/**/*</excludes>
+                            <includeArtifactIds>
+                                github-api
+                            </includeArtifactIds>
+                            <outputDirectory>${project.build.directory}/classes</outputDirectory>
+                            <overWriteReleases>true</overWriteReleases>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.6.1</version>
                 <configuration>
                     <source>1.6</source>
                     <target>1.6</target>

--- a/src/main/java/com/mhackner/bamboo/AbstractGitHubStatusAction.java
+++ b/src/main/java/com/mhackner/bamboo/AbstractGitHubStatusAction.java
@@ -85,8 +85,7 @@ public abstract class AbstractGitHubStatusAction {
                            String planResultKey, String context) {
         String url = bambooUrl.withBaseUrlFromConfiguration("/browse/" + planResultKey);
         try {
-            GitHub gitHub = GitHub.connectToEnterprise(gitHubEndpoint, repo.getUsername(),
-                    encryptionService.decrypt(repo.getEncryptedPassword()));
+            GitHub gitHub = GitHub.connectToEnterprise(gitHubEndpoint, repo.getUsername(), repo.getPassword());
             GHRepository repository = gitHub.getRepository(repo.getRepository());
             sha = repository.getCommit(sha).getSHA1();
             repository.createCommitStatus(sha, status, url, null, context);


### PR DESCRIPTION
I don't particularly know what I'm doing, but I updated the build to use a newer version and changed the call to use `repo.getPassword()` to make the plugin work with Bamboo 15.  Also, I was getting exceptions about the classes from `github-api` being missing, so I added a `maven-dependency-plugin` execution to copy those classes into the bundle.