### PR TITLE
Update org.kohsuke.github-api to 1.90

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.kohsuke</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.69</version>
+            <version>1.90</version>
         </dependency>
         <dependency>
             <groupId>com.atlassian.bamboo</groupId>


### PR DESCRIPTION
This release includes https://github.com/kohsuke/github-api/commit/7735edeae87652c1fa8196e7956851a39f5a84d4 which fixes the issue where failed to parse a response id larger than int.

Fixes #31 