### PR TITLE
Adds nullcheck for buildKey in Configuration defaults.

### DIFF
--- a/src/main/java/com/mhackner/bamboo/Configuration.java
+++ b/src/main/java/com/mhackner/bamboo/Configuration.java
@@ -50,7 +50,12 @@ public class Configuration extends BaseBuildConfigurationAwarePlugin
 
     @Override
     public void addDefaultValues(@NotNull BuildConfiguration buildConfiguration) {
-        Plan plan = planManager.getPlanByKey(PlanKeys.getPlanKey(buildConfiguration.getString("buildKey")));
+        String buildKey = buildConfiguration.getString("buildKey");
+        if(buildKey == null){
+            buildConfiguration.setProperty(CONFIG_KEY, ImmutableList.of());
+            return;
+        }
+        Plan plan = planManager.getPlanByKey(PlanKeys.getPlanKey(buildKey));
         RepositoryDefinition repo = Iterables.find(ghReposFrom(plan), DEFAULT_REPO_PREDICATE, null);
         buildConfiguration.setProperty(CONFIG_KEY, repo == null
                 ? ImmutableList.of()


### PR DESCRIPTION
This caused an error when using this plugin in combination with bamboo
specs in linked repositories (see
https://confluence.atlassian.com/bamboo/enabling-repository-stored-bamboo-specs-938641941.html).

Bamboo specs in linked repositories are built outside of the context of
a build. I'm guessing that's why they don't have a build key.